### PR TITLE
Publish unit test results and code coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,13 @@ For more information see the [Code of Conduct FAQ](https://opensource.microsoft.
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 ## Unit tests
-Run unit tests from the project root by running:
+Run unit tests from the project root either with the built-in `unittest` module:
 
     python -m unittest discover
+
+Or by using `pytests`, which can produce reports both for unit test success and for code coverage, by
+using the following invocation:
+
+    pip install pytest
+    pip install pytest-cov
+    pytest tests --doctest-modules --junitxml=junit/test-results.xml --cov=callgraph --cov-report=xml --cov-report=html

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,8 +29,23 @@ jobs:
       versionSpec: '$(python.version)'
       architecture: 'x64'
 
-  - script: python -m unittest discover
+  - script: |
+      pip install pytest
+      pip install pytest-cov
+      pytest tests --doctest-modules --junitxml=junit/test-results.xml --cov=callgraph --cov-report=xml --cov-report=html
     displayName: 'Unit Tests'
+
+  - task: PublishTestResults@2
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFiles: '**/test-*.xml'
+      testRunTitle: 'Publish test results for Python $(python.version)'
+
+  - task: PublishCodeCoverageResults@1
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+      reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
 
 - job: 'GenerateSamples'
   dependsOn: 'Test'


### PR DESCRIPTION
Also, run tests with pytest, which needs to be installed in the agent.

Fixes #23.